### PR TITLE
Add basic containerized build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,9 @@
+FROM rust:latest as builder
+WORKDIR /usr/src/anki-sync-server-rs
+COPY . .
+RUN cargo install --path .
+
+FROM debian:stable-slim as runner
+#RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/ankisyncd /usr/local/bin/ankisyncd
+CMD ["ankisyncd"]

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,24 @@
+# Containers 
+
+This file contains:
+
+1. How to use container to build binary
+2. How to run binary in a container
+
+In this manual we will use `podman` command for containers creation/management but it can seamlessly be replaced with `docker` every time it is used.
+
+The `Containerfile` at the root of the repository controls the build process.
+
+## Building in container, running on host
+
+1. In the root of the repository run: `podman build -t anki-sync-server-rs/builder:latest .`
+2. Then exfiltrate the binary from the container: `podman run --rm --entrypoint cat anki-sync-server-rs/builder:latest /usr/local/cargo/bin/ankisyncd > ankisyncd`
+3. Use the `ankisyncd` binary obtained as usual
+
+
+## Building and running in container
+
+1. Build the container: `podman build -t anki-sync-server-rs/runner:latest .`
+2. Run it in foreground: `podman run -it anki-sync-server-rs/runner:latest`
+
+


### PR DESCRIPTION
This pull request adds basic container building & running for this ankisyncd.
Docs are provided in `docs/container.md`

This allow for easy development/build without installing any toolchain.

Big thanks to @dobefore for creating this anki sync server in rust!