### PR TITLE
make rustls as an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ keywords = ["Anki","actix-web","server"]
 repository = "https://github.com/ankicommunity/anki-sync-server-rs.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+build = "build.rs"
+
 [dependencies]
 thiserror = "1.0.30"
 actix-web = { version = "3", features=["rustls"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ repository = "https://github.com/ankicommunity/anki-sync-server-rs.git"
 
 [dependencies]
 thiserror = "1.0.30"
-rustls = "0.18"
-actix-web = { version = "3", features = ["rustls"] }
+actix-web = { version = "3", features=["rustls"]}
 actix-multipart = "0.3"
 async-std = "1.8"
 futures-util = "0.3"
@@ -35,5 +34,6 @@ clap="3.0.0-beta.5"
 version = "0.25.1"
 features = ["bundled"]
 
-
-
+[dependencies.rustls]
+optional = true
+version = "0.18"

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Use the same base url for both the `Sync url` and the `Media sync url`, but appe
 Even though the AnkiDroid interface will request an email address, this is not required; it will simply be the username you configured with `ankisyncd.exe user -a`.
 #### encrypted HTTP connection
 Due to Android policy change,some ankidroid versions need
-https transportation.Ankisyncd allow embeded self-signed certicate verify
-used in LAN environment.open `Settings.toml` with text
+https transportation.Though we recommend reverse proxies such as `Nginx` and `Caddy` to perform secure connection,
+ankisyncd allow for embeded self-signed certicate 
+used in LAN environment.If you want to use that feature,you must run cargo build command with flag
+ `--feature rustls`.Then open `Settings.toml` with text
 editor,modify following lines:
 ```
 #make ssl_enable true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+fn main() {
+    let pat = "rustls";
+    let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
+    match env::var_os(key) {
+        Some(_) => {
+            println!("{}", format!("cargo:rustc-cfg=feature=\"{}\"", pat))
+        }
+        None => {}
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,7 @@ use std::env;
 fn main() {
     let pat = "rustls";
     let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
-    match env::var_os(key) {
-        Some(_) => {
-            println!("{}", format!("cargo:rustc-cfg=feature=\"{}\"", pat))
-        }
-        None => {}
-    }
+    if env::var_os(key).is_some() {
+           println!("{}", format!("cargo:rustc-cfg=feature=\"{}\"", pat))
+            }
 }

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,6 @@ fn main() {
     let pat = "rustls";
     let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
     if env::var_os(key).is_some() {
-           println!("{}", format!("cargo:rustc-cfg=feature=\"{}\"", pat))
-            }
+        println!("{}", format!("cargo:rustc-cfg=feature=\"{}\"", pat))
+    }
 }

--- a/scripts/cc.sh
+++ b/scripts/cc.sh
@@ -33,14 +33,14 @@ export PATH="$HOME/arm-linux-musleabihf-cross/bin:$PATH"
 export OPENSSL_LIB_DIR=/home/ubuntu/openssl-armv7/lib
 export OPENSSL_INCLUDE_DIR=/home/ubuntu/openssl-armv7/include
 export OPENSSL_STATIC=true
-# cross build for armv7
+# cross build for armv7 enable feature --features rustls
  cargo build --target armv7-unknown-linux-musleabihf --release
 
 mkdir ankisyncd-arm
-cp target/armv7-unknown-linux-musleabihf/release/ankisyncd ankisyncd-arm
-cp Settings.toml ankisyncd-arm
-tar -czvf ankisyncd-$version-arm.tar.gz ankisyncd-arm
-mv ankisyncd-$version-arm.tar.gz ~
+cp target/armv7-unknown-linux-musleabihf/release/ankisyncd ankisyncd-arm/
+cp Settings.toml ankisyncd-arm/
+tar -czvf ankisyncd-$version-arm.tar.gz ankisyncd-arm/
+mv ankisyncd-$version-linux-arm.tar.gz ~
 fi
 
 #for x86-64
@@ -52,10 +52,11 @@ export CC=
 export OPENSSL_LIB_DIR=/home/ubuntu/openssl_x64
 export OPENSSL_INCLUDE_DIR=/home/ubuntu/openssl_x64/include
 export OPENSSL_STATIC=true
+#  enable feature --features rustls
 cargo build --release --target=x86_64-unknown-linux-musl
 
 mkdir ankisyncd-linux
-cp target/x86_64-unknown-linux-musl/release/ankisyncd ankisyncd-linux
-cp Settings.toml ankisyncd-linux
-tar -czvf ankisyncd-$version-linux.tar.gz ankisyncd-linux
+cp target/x86_64-unknown-linux-musl/release/ankisyncd ankisyncd-linux/
+cp Settings.toml ankisyncd-linux/
+tar -czvf ankisyncd-$version-linux.tar.gz ankisyncd-linux/
 mv ankisyncd-$version-linux.tar.gz ~

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
-mod error;
+#![allow(unused_imports)]
 mod db;
+mod error;
 mod media;
 pub mod parse;
 pub mod session;
@@ -17,7 +18,9 @@ use parse::{
     conf::{create_conf, LocalCert, Settings},
     parse,
 };
+#[cfg(feature = "rustls")]
 use rustls::internal::pemfile::{certs, pkcs8_private_keys};
+#[cfg(feature = "rustls")]
 use rustls::{NoClientAuth, ServerConfig};
 use std::fs::File;
 use std::io::BufReader;
@@ -25,13 +28,12 @@ use std::path::Path;
 use std::sync::Mutex;
 use user::create_account;
 /// "cert.pem" "key.pem"
+#[cfg(feature = "rustls")]
 fn load_ssl(localcert: LocalCert) -> Option<ServerConfig> {
     // load ssl keys
-    let enable = localcert.ssl_enable;
-    if enable {
+    if localcert.ssl_enable {
         let cert = localcert.cert_file;
         let key = localcert.key_file;
-
         let mut config = ServerConfig::new(NoClientAuth::new());
         let cert_file = &mut BufReader::new(File::open(cert).unwrap());
         let key_file = &mut BufReader::new(File::open(key).unwrap());
@@ -47,8 +49,53 @@ fn load_ssl(localcert: LocalCert) -> Option<ServerConfig> {
         None
     }
 }
+async fn server_builder(addr: String) -> Result<(), ()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    env_logger::init();
+    let session_manager = web::Data::new(Mutex::new(SessionManager::new()));
+    let tr = I18n::template_only();
+    let bd = web::Data::new(Mutex::new(Backend::new(tr, true)));
+    HttpServer::new(move || {
+        App::new()
+            .app_data(session_manager.clone())
+            .app_data(bd.clone())
+            .service(welcome)
+            .service(favicon)
+            .service(web::resource("/{url}/{name}").to(sync_app_no_fail))
+            .wrap(middleware::Logger::default())
+    })
+    .bind(addr)
+    .expect("Failed to bind with rustls.")
+    .run()
+    .await
+    .expect("server build error");
+    Ok(())
+}
+#[cfg(feature = "rustls")]
+async fn server_builder_tls(addr: String, c: ServerConfig) -> Result<(), ()> {
+    std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
+    env_logger::init();
+    let session_manager = web::Data::new(Mutex::new(SessionManager::new()));
+    let tr = I18n::template_only();
+    let bd = web::Data::new(Mutex::new(Backend::new(tr, true)));
+    HttpServer::new(move || {
+        App::new()
+            .app_data(session_manager.clone())
+            .app_data(bd.clone())
+            .service(welcome)
+            .service(favicon)
+            .service(web::resource("/{url}/{name}").to(sync_app_no_fail))
+            .wrap(middleware::Logger::default())
+    })
+    .bind_rustls(addr, c)
+    .expect("Failed to bind with rustls.")
+    .run()
+    .await
+    .expect("server build error");
+    Ok(())
+}
 #[actix_web::main]
-async fn main() -> Result<(),()> {
+async fn main() -> Result<(), ()> {
     //cli argument  parse
     let matches = parse();
     // set config path if parsed and write conf settings
@@ -63,7 +110,6 @@ async fn main() -> Result<(),()> {
     create_auth_db(&auth_path).expect("Failed to create auth database.");
     // enter into account manage if subcommand exists,else run server
     if matches.subcommand_name().is_some() {
-
         if let Err(e) = user_manage(matches, auth_path) {
             eprintln!("Error managing users: {}", e);
             return Err(());
@@ -76,33 +122,17 @@ async fn main() -> Result<(),()> {
             eprintln!("Error creating account: {}", e);
             return Err(());
         }
-        let ssl_config = load_ssl(conf.localcert);
-        // parse ip address
         let addr = format!("{}:{}", conf.address.host, conf.address.port);
-
-        std::env::set_var("RUST_LOG", "actix_server=info,actix_web=info");
-        env_logger::init();
-        let session_manager = web::Data::new(Mutex::new(SessionManager::new()));
-        let tr = I18n::template_only();
-        let bd = web::Data::new(Mutex::new(Backend::new(tr, true)));
-        let s = HttpServer::new(move || {
-            App::new()
-                .app_data(session_manager.clone())
-                .app_data(bd.clone())
-                .service(welcome)
-                .service(favicon)
-                .service(web::resource("/{url}/{name}").to(sync_app_no_fail))
-                .wrap(middleware::Logger::default())
-        });
-        let result = if let Some(c) = ssl_config {
-            s.bind_rustls(addr, c).expect("Failed to bind with rustls.").run().await
-        } else {
-            s.bind(addr).expect("Failed to bind, please check config.").run().await
-        };
-        if let Err(e) = result {
-            eprintln!("Bind error: {}", e);
-            return Err(());
-        };
+        let lc = conf.localcert;
+        let enable = lc.ssl_enable;
+        #[cfg(feature = "rustls")]
+        let tls_conf = load_ssl(lc);
+        if enable {
+            #[cfg(feature = "rustls")]
+            server_builder_tls(addr, tls_conf.unwrap()).await?;
+            return Ok(());
+        }
+        server_builder(addr).await?;
         Ok(())
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -80,8 +80,10 @@ root_dir="."
 [account]
 username=""
 password=""
-        
-# embeded encrypted http /https credential if in Intranet
+
+# Only in a situation running cargo build command with flag --feature rustls
+# can this take effect.
+# embeded encrypted http connection if in LAN
 # true to enable ssl or false
 [localcert]
 ssl_enable=false

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,6 +5,53 @@ pub mod conf {
     use serde::Deserialize;
     use std::fs;
     use std::path::Path;
+    static CONF_TEXT: &str = r#"
+    [address]
+    host="0.0.0.0"
+    port = "27701"
+    # use current executable path ,only set filename
+    [paths]
+    # set root_dir as working dir where server data(collections folder) and database(auth.db...) reside
+    root_dir="."
+    #following three lines are unnessesary and can be skipped
+     data_root = ""
+     auth_db_path = ""
+     session_db_path = ""
+            
+    # user will be added 
+    #into auth.db if not empty,and two fields must not be empty
+    [account]
+    username=""
+    password=""
+    "#;
+    static CONF_TEXT_SSL: &str = r#"
+    [address]
+    host="0.0.0.0"
+    port = "27701"
+    # use current executable path ,only set filename
+    [paths]
+    # set root_dir as working dir where server data(collections folder) and database(auth.db...) reside
+    root_dir="."
+    #following three lines are unnessesary and can be skipped
+     data_root = ""
+     auth_db_path = ""
+     session_db_path = ""
+            
+    # user will be added 
+    #into auth.db if not empty,and two fields must not be empty
+    [account]
+    username=""
+    password=""
+    
+    # Only in a situation running cargo build command with flag --feature rustls
+    # can this take effect.
+    # embeded encrypted http connection if in LAN
+    # true to enable ssl or false
+    [localcert]
+    ssl_enable=false
+    cert_file=""
+    key_file=""
+    "#;
     #[derive(Debug, Deserialize)]
     pub struct Address {
         pub host: String,
@@ -22,6 +69,7 @@ pub mod conf {
         pub username: String,
         pub password: String,
     }
+    #[cfg(feature = "rustls")]
     #[derive(Debug, Deserialize)]
     pub struct LocalCert {
         pub ssl_enable: bool,
@@ -33,6 +81,7 @@ pub mod conf {
         pub address: Address,
         pub paths: Paths,
         pub account: Account,
+        #[cfg(feature = "rustls")]
         pub localcert: LocalCert,
     }
     impl Settings {
@@ -62,34 +111,11 @@ pub mod conf {
     }
     /// create configure file and write contents to it
     pub fn create_conf(p: &Path) {
-        let content = r#"
-[address]
-host="0.0.0.0"
-port = "27701"
-# use current executable path ,only set filename
-[paths]
-# set root_dir as working dir where server data(collections folder) and database(auth.db...) reside
-root_dir="."
-#following three lines are unnessesary and can be skipped
- data_root = ""
- auth_db_path = ""
- session_db_path = ""
-        
-# user will be added 
-#into auth.db if not empty,and two fields must not be empty
-[account]
-username=""
-password=""
-
-# Only in a situation running cargo build command with flag --feature rustls
-# can this take effect.
-# embeded encrypted http connection if in LAN
-# true to enable ssl or false
-[localcert]
-ssl_enable=false
-cert_file=""
-key_file=""
-"#;
+        let content = if cfg!(feature = "rustls") {
+            CONF_TEXT_SSL
+        } else {
+            CONF_TEXT
+        };
         if !p.exists() {
             if let Err(_e) = fs::write(p, content) {
                 panic!("Cannot write config file at '{}'", p.display());

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,3 +1,4 @@
+use crate::error::ApplicationError;
 use anki::collection::{open_collection, Collection};
 use anki::i18n::I18n;
 use anki::log;
@@ -11,7 +12,6 @@ use std::fs;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
-use crate::error::ApplicationError;
 
 #[derive(Debug, Clone)]
 pub struct Session {
@@ -84,15 +84,16 @@ fn map_skey_session(session: Session, skey: &str) -> io::Result<Session> {
 }
 
 fn to_vec(row: &Row) -> Result<Vec<String>, rusqlite::Error> {
-    Ok(vec![
-        row.get(0)?,
-        row.get(1)?,
-        row.get(2)?,
-    ])
+    Ok(vec![row.get(0)?, row.get(1)?, row.get(2)?])
 }
-fn query_vec(sql: &str, conn: &Connection, query_entry: &str) -> Result<Option<Vec<String>>, ApplicationError> {
+fn query_vec(
+    sql: &str,
+    conn: &Connection,
+    query_entry: &str,
+) -> Result<Option<Vec<String>>, ApplicationError> {
     let mut stmt = conn.prepare(sql)?;
-    let r = stmt.query_row([query_entry], |row| to_vec(row))
+    let r = stmt
+        .query_row([query_entry],  to_vec)
         .optional()?;
     Ok(r)
 }
@@ -119,7 +120,7 @@ impl SessionManager {
         &mut self,
         skey: &str,
         session_db_path: P,
-    ) -> Result<Option<Session>, ApplicationError>{
+    ) -> Result<Option<Session>, ApplicationError> {
         let mut sesss = self
             .clone()
             .sessions
@@ -133,15 +134,25 @@ impl SessionManager {
             let conn = Connection::open(&session_db_path)?;
             let sql = "SELECT hkey, username, path FROM session WHERE skey=?";
             let v = query_vec(sql, &conn, skey)?;
-            if let Err((_,e)) = conn.close() { return Err(ApplicationError::Sqlite(e))}
+            if let Err((_, e)) = conn.close() {
+                return Err(ApplicationError::Sqlite(e));
+            }
             if let Some(mut vc) = v {
                 let username = match vc.get(1) {
                     Some(u) => u,
-                    None => return Err(ApplicationError::ValueNotFound("username not found in matching sql result".to_string())),
+                    None => {
+                        return Err(ApplicationError::ValueNotFound(
+                            "username not found in matching sql result".to_string(),
+                        ))
+                    }
                 };
                 let path = match vc.get(2) {
                     Some(p) => p,
-                    None => return Err(ApplicationError::ValueNotFound("path not found in matching sql result".to_string())),
+                    None => {
+                        return Err(ApplicationError::ValueNotFound(
+                            "path not found in matching sql result".to_string(),
+                        ))
+                    }
                 };
                 let session = Session::from(skey, username, path);
                 // add into hashmap
@@ -154,7 +165,12 @@ impl SessionManager {
             }
         }
     }
-    pub fn save<P: AsRef<Path>>(&mut self, hkey: String, session: Session, session_db_path: P) -> Result<(), ApplicationError>{
+    pub fn save<P: AsRef<Path>>(
+        &mut self,
+        hkey: String,
+        session: Session,
+        session_db_path: P,
+    ) -> Result<(), ApplicationError> {
         self.sessions.insert(hkey.clone(), session.clone());
         // db insert ops
         let session_db = session_db_path.as_ref();
@@ -177,11 +193,17 @@ impl SessionManager {
                 &format!("{}", session.path.display()),
             ],
         )?;
-        if let Err((_,e)) = conn.close() { return Err(ApplicationError::Sqlite(e));};
+        if let Err((_, e)) = conn.close() {
+            return Err(ApplicationError::Sqlite(e));
+        };
         Ok(())
     }
 
-    pub fn load<P: AsRef<Path>>(&mut self, hkey: &str, session_db_path: P) -> Result<Option<Session>, ApplicationError> {
+    pub fn load<P: AsRef<Path>>(
+        &mut self,
+        hkey: &str,
+        session_db_path: P,
+    ) -> Result<Option<Session>, ApplicationError> {
         let sess = self.clone().sessions.remove(hkey);
 
         if let Some(session) = sess {
@@ -200,23 +222,36 @@ impl SessionManager {
 
             let sql1 = "SELECT skey, username, path FROM session WHERE hkey=?";
             let o = query_vec(sql1, &conn, hkey)?;
-            if let Err((_,e)) = conn.close() { return Err(ApplicationError::Sqlite(e));};
+            if let Err((_, e)) = conn.close() {
+                return Err(ApplicationError::Sqlite(e));
+            };
             if let Some(v) = o {
                 let skey = match v.get(0) {
                     Some(s) => s,
-                    None => return Err(ApplicationError::ValueNotFound("skey not found in matching sql result".to_string())),
+                    None => {
+                        return Err(ApplicationError::ValueNotFound(
+                            "skey not found in matching sql result".to_string(),
+                        ))
+                    }
                 };
                 let username = match v.get(1) {
                     Some(u) => u,
-                    None => return Err(ApplicationError::ValueNotFound("username not found in matching sql result".to_string())),
+                    None => {
+                        return Err(ApplicationError::ValueNotFound(
+                            "username not found in matching sql result".to_string(),
+                        ))
+                    }
                 };
                 let path = match v.get(2) {
                     Some(p) => p,
-                    None => return Err(ApplicationError::ValueNotFound("path not found in matching sql result".to_string())),
+                    None => {
+                        return Err(ApplicationError::ValueNotFound(
+                            "path not found in matching sql result".to_string(),
+                        ))
+                    }
                 };
 
-                let session =
-                    Session::from(skey, username, path);
+                let session = Session::from(skey, username, path);
                 self.borrow_mut()
                     .sessions
                     .insert(hkey.to_owned(), session.clone());

--- a/src/session.rs
+++ b/src/session.rs
@@ -92,9 +92,7 @@ fn query_vec(
     query_entry: &str,
 ) -> Result<Option<Vec<String>>, ApplicationError> {
     let mut stmt = conn.prepare(sql)?;
-    let r = stmt
-        .query_row([query_entry],  to_vec)
-        .optional()?;
+    let r = stmt.query_row([query_entry], to_vec).optional()?;
     Ok(r)
 }
 #[derive(Debug, Clone)]

--- a/src/user.rs
+++ b/src/user.rs
@@ -24,14 +24,12 @@ pub enum UserError {
     Unknown,
 }
 
-
 impl From<(rusqlite::Connection, rusqlite::Error)> for UserError {
     fn from(error: (rusqlite::Connection, rusqlite::Error)) -> Self {
         let (_, err) = error;
         UserError::Sqlite(err)
     }
 }
-
 
 fn create_salt() -> String {
     // create salt
@@ -43,7 +41,7 @@ fn set_password_for_user<P: AsRef<Path>>(
     username: &str,
     new_password: &str,
     dbpath: P,
-) -> Result<(),UserError> {
+) -> Result<(), UserError> {
     if user_exists(username, &dbpath)? {
         let salt = create_salt();
         let hash = create_pass_hash(username, new_password, &salt);
@@ -74,7 +72,7 @@ fn add_user_to_auth_db<P: AsRef<Path>>(
     conn.execute(sql, [username, pass_hash.as_str()])?;
     conn.close()?;
     let user_path = match dbpath.as_ref().to_owned().parent() {
-        Some(p) => p.join("collections").join(username), 
+        Some(p) => p.join("collections").join(username),
         None => return Err(UserError::Unknown),
     };
     create_user_dir(user_path)?;
@@ -100,7 +98,7 @@ fn del_user<P: AsRef<Path>>(username: &str, dbpath: P) -> Result<(), UserError> 
     Ok(())
 }
 // insert record into db if username is not empty in Settings.toml
-pub fn create_account<P: AsRef<Path>>(account: Account, dbpath: P) -> Result<(), UserError>{
+pub fn create_account<P: AsRef<Path>>(account: Account, dbpath: P) -> Result<(), UserError> {
     // insert record into db if username is not empty,
     let name = account.username;
     let pass = account.password;
@@ -135,7 +133,7 @@ pub fn create_auth_db<P: AsRef<Path>>(p: P) -> Result<(), UserError> {
 }
 
 /// command-line user management
-pub fn user_manage<P: AsRef<Path>>(matches: ArgMatches, dbpath: P) -> Result<(), UserError>{
+pub fn user_manage<P: AsRef<Path>>(matches: ArgMatches, dbpath: P) -> Result<(), UserError> {
     match matches.subcommand() {
         Some(("user", user_mach)) => {
             if user_mach.is_present("add") {
@@ -183,10 +181,11 @@ pub fn user_list<P: AsRef<Path>>(dbpath: P) -> Result<Option<Vec<String>>, UserE
     let mut stmt = conn.prepare(sql)?;
     let rows = stmt.query_map([], |r| r.get(0))?;
 
-    let v1 = rows
-        .into_iter()
-        .collect::<Result<Vec<String>,_>>();
-    let v = match v1 { Ok(a) => a, Err(e) => return Err(UserError::Sqlite(e)),};
+    let v1 = rows.into_iter().collect::<Result<Vec<String>, _>>();
+    let v = match v1 {
+        Ok(a) => a,
+        Err(e) => return Err(UserError::Sqlite(e)),
+    };
     let r = if v.is_empty() { None } else { Some(v) };
     Ok(r)
 }
@@ -213,7 +212,10 @@ fn create_pass_hash(username: &str, password: &str, salt: &str) -> String {
     pass_hash
 }
 
-pub fn authenticate<P: AsRef<Path>>(hkreq: &HostKeyRequest, auth_db_path: P) -> Result<bool,UserError> {
+pub fn authenticate<P: AsRef<Path>>(
+    hkreq: &HostKeyRequest,
+    auth_db_path: P,
+) -> Result<bool, UserError> {
     let auth_db = auth_db_path.as_ref();
 
     let conn = Connection::open(auth_db)?;


### PR DESCRIPTION
refer to #11 ,make rustls as an optional feature
Unless running cargo build command with flag `--features rustls` ,tls http will not be enabled.
We recommend reverse proxies such as nginx to perform secure http connection,instead of rustls.