### PR TITLE
container(docker) build for arm 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,8 @@ FROM rust:latest as builder
 WORKDIR /usr/src/anki-sync-server-rs
 # copy from host to container
 COPY . .
+# prost-build failed for armv7h https://github.com/ankicommunity/anki-sync-server-rs/issues/22 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes protobuf-compiler
 RUN cargo build --release  
 
 FROM debian:stable-slim as runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM rust:latest as builder
 WORKDIR /usr/src/anki-sync-server-rs
 # copy from host to container
 COPY . .
+# prost-build failed for armv7h https://github.com/ankicommunity/anki-sync-server-rs/issues/22 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes protobuf-compiler
 RUN cargo build --release  
 
 FROM debian:stable-slim as runner


### PR DESCRIPTION
refer to #22. it seems building for armv7h will produce prost-build error.

I tested  ARM aarch64 (raspberry ubuntu 64bit) so that I find it goes well without adding that command.

All in all,I will add the command to docker file in case some platforms behave differently.Thank to @mktree  for the contribution.