### PR TITLE
fix cross compiling fail for arm

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -17,11 +17,19 @@ rustflags = ["-C", "target-feature=+crt-static",
  "-C", "link-args=-static"]
 
 [target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-musleabihf-gcc"
+#linker = "arm-linux-musleabihf-gcc"
+linker = "arm-linux-musleabihf-ld"
 rustflags  = [
   "-C", "target-feature=+crt-static",
     "-C", "link-args=-static",
 ]
+
+[target.arm-unknown-linux-musleabihf]
+linker = "arm-linux-musleabihf-ld"
+ rustflags  = [
+   "-C", "target-feature=+crt-static",
+    "-C", "link-args=-static",
+ ]
 
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"
@@ -36,8 +44,3 @@ rustflags = ["-C", "target-feature=+crt-static",
 #[source.tuna]
 #registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"
 
-
-#for linux cmd line use
-#[net]
-#retry = 2 # 失败 自动重试 次数
-#git-fetch-with-cli = true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
     tags: ["[0-9]+.[0-9]+.[0-9]+*"]
 
 jobs:
-  armv7:
-    name: Build Armv7
+  armv6:
+    name: Build armv6
     runs-on: ubuntu-latest
     # after every step is finished,exporting to PATH will be clear,so in next step ,need re-export
     steps:
@@ -28,8 +28,8 @@ jobs:
           ls anki
 
       # this may not succeed?
-      - name: Add cargo taget armv7
-        run: rustup target add armv7-unknown-linux-musleabihf
+      - name: Add cargo taget armv6
+        run: rustup target add arm-unknown-linux-musleabihf
 
       - name: Download arm-musl-gcc
         run: wget  -P $HOME https://musl.cc/arm-linux-musleabihf-cross.tgz
@@ -61,38 +61,49 @@ jobs:
 
           mkdir -p $HOME/openssl
           cd openssl-1.1.1f
-          ./config shared --prefix=$HOME/openssl && make 
+          ./config shared --prefix=$HOME/anki-sync-server-rs/openssl && make 
           make install
           cd ..
-          ls $HOME/openssl/include
-      # build static-linked binary for armv7 (also suitable for aarch64)
+          ls $HOME/anki-sync-server-rs/openssl/include
+
+      # compile sqlite
+      - name: Download and unpack lib sqlite3
+        run: |
+          wget --no-check-certificate https://www.sqlite.org/2022/sqlite-autoconf-3380200.tar.gz
+          tar -zxvf sqlite-autoconf-3380200.tar.gz -C .
+      - name: compile sqlite3
+        run: |
+          mkdir -p $HOME/sql
+          cd sqlite-autoconf-3380200
+          ./configure CC=$HOME/rpitools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc  --host=arm-linux --prefix=$HOME/sql
+          make && make install
+      
+      # build static-linked binary for armv6 (also suitable for aarch64)
       - name: Build 
         run: | 
-          ls $HOME/openssl/lib
-          export PATH="$HOME/rpitools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH"
-          export CC=arm-linux-gnueabihf-gcc
-          
-          export OPENSSL_LIB_DIR=$HOME/openssl/lib
-          export OPENSSL_INCLUDE_DIR=$HOME/openssl/include
+          ls $HOME/anki-sync-server-rs/openssl/lib
+         
+          export OPENSSL_LIB_DIR=$HOME/anki-sync-server-rs/openssl/lib
+          export OPENSSL_INCLUDE_DIR=$HOME/anki-sync-server-rs/openssl/include
           export OPENSSL_STATIC=true
 
           export PATH="$HOME/arm-linux-musleabihf-cross/bin:$PATH"
-          
-          cargo build --target armv7-unknown-linux-musleabihf --release --features tls
+          cp -r $HOME/sql .
+          cargo build --target arm-unknown-linux-musleabihf --release --features tls
   
       - name: Create output directory
         run: mkdir output
 
       - name: Copy files to output
         run: |
-          cp target/armv7-unknown-linux-musleabihf/release/ankisyncd output/
+          cp target/arm-unknown-linux-musleabihf/release/ankisyncd output/
           cp scripts/Settings.toml output/
          
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: armv7
+          name: armv6
           path: output/*
 
   linux:
@@ -236,7 +247,7 @@ jobs:
       - linux
       - macos
       - windows
-      - armv7
+      - armv6
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -255,7 +266,7 @@ jobs:
           echo "::set-output name=linuxdir::ankisyncd_${MAJOR}.${MINOR}.${PATCH}_linux_x86_64_glibc"
           echo "::set-output name=macosdir::ankisyncd_${MAJOR}.${MINOR}.${PATCH}_macOS_x86_64"
           echo "::set-output name=windowsdir::ankisyncd_${MAJOR}.${MINOR}.${PATCH}_windows_x86_64"
-          echo "::set-output name=armv7dir::ankisyncd_${MAJOR}.${MINOR}.${PATCH}_linux_armv7_muslc"
+          echo "::set-output name=armv6dir::ankisyncd_${MAJOR}.${MINOR}.${PATCH}_linux_armv6_muslc"
           echo "::set-output name=innerdir::ankisyncd-${VERSION}"
       - name: Create Release Draft
         id: create_release
@@ -267,30 +278,30 @@ jobs:
           release_name: ${{ steps.info.outputs.version }} Release
           draft: true
       
-      - name: Create armv7 Directory
-        run: mkdir -p ${{ steps.info.outputs.armv7dir }}
+      - name: Create armv6 Directory
+        run: mkdir -p ${{ steps.info.outputs.armv6dir }}
 
-      - name: Download armv7 Artifacts
+      - name: Download armv6 Artifacts
         uses: actions/download-artifact@v2
         with:
-          name: armv7
-          path: ${{ steps.info.outputs.armv7dir }}
+          name: armv6
+          path: ${{ steps.info.outputs.armv6dir }}
 
-      - name: Restore armv7 File Modes
+      - name: Restore armv6 File Modes
         run: |
-          chmod 755 ${{ steps.info.outputs.armv7dir }}/ankisyncd*
+          chmod 755 ${{ steps.info.outputs.armv6dir }}/ankisyncd*
 
-      - name: Create armv7 tarball
-        run: tar -zcvf ${{ steps.info.outputs.armv7dir }}.tar.gz ${{ steps.info.outputs.armv7dir }}
+      - name: Create armv6 tarball
+        run: tar -zcvf ${{ steps.info.outputs.armv6dir }}.tar.gz ${{ steps.info.outputs.armv6dir }}
 
-      - name: Upload armv7 Artifact
+      - name: Upload armv6 Artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.info.outputs.armv7dir }}.tar.gz
-          asset_name: ${{ steps.info.outputs.armv7dir }}.tar.gz
+          asset_path: ./${{ steps.info.outputs.armv6dir }}.tar.gz
+          asset_name: ${{ steps.info.outputs.armv6dir }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Create Linux Directory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,6 @@ urlparse = "0.7.3"
 hex = "0.4.3"
 anki = {path="anki/rslib"}
 clap = { version = "3.1.3", features = ["cargo"] }
-[dependencies.rusqlite]
-version = "0.26"
-features = ["bundled"]
 
 [dependencies.rustls]
 optional = true
@@ -46,3 +43,18 @@ version = "0.20.4"
 [dependencies.rustls-pemfile]
 optional = true
 version = "0.3.0"
+
+[target.'cfg(not(arm))'.dependencies]
+rusqlite = {version = "0.26.2",features = ["bundled"]}
+
+# native build on host or docker
+[target.arm-unknown-linux-gnueabihf.dependencies]
+rusqlite = {version = "0.26.2",features = ["bundled"]}
+
+# native build on host or docker
+[target.armv7-unknown-linux-gnueabihf.dependencies]
+rusqlite = {version = "0.26.2",features = ["bundled"]}
+
+#use cross-compiled static sqlite3 library
+[target.arm-unknown-linux-musleabihf.dependencies]
+rusqlite = "0.26.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,10 @@ rusqlite = {version = "0.26.2",features = ["bundled"]}
 [target.armv7-unknown-linux-gnueabihf.dependencies]
 rusqlite = {version = "0.26.2",features = ["bundled"]}
 
+# native build on host or docker
+[target.armv7h-unknown-linux-gnueabihf.dependencies]
+rusqlite = {version = "0.26.2",features = ["bundled"]}
+
 #use cross-compiled static sqlite3 library
 [target.arm-unknown-linux-musleabihf.dependencies]
 rusqlite = "0.26.2"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,22 @@
 use std::env;
+use std::path::Path;
+
 fn main() {
-    let pat = "rustls";
-    let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
-    if env::var_os(key).is_some() {
-        println!("cargo:rustc-cfg=feature=\"{}\"", pat)
-    }
+   // should consider native build on arm platform
+
+   // used in cross compile 
+   // arm-unknown-linux-musleabihf
+   let target = env::var("TARGET").expect("TARGET was not set");
+   if target.contains("arm") && target.contains("musl") {
+      // find and link static sqlite3 lib
+    let sql=Path::new(&env::current_dir().unwrap()).join("sql/lib");
+    println!("cargo:rustc-link-search=native={}",sql.display());
+    println!("cargo:rustc-link-lib=static=sqlite3");
+   }
+
+   let pat = "rustls";
+   let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
+   if env::var_os(key).is_some() {
+       println!("cargo:rustc-cfg=feature=\"{}\"", pat)
+   }
 }

--- a/build.rs
+++ b/build.rs
@@ -2,21 +2,21 @@ use std::env;
 use std::path::Path;
 
 fn main() {
-   // should consider native build on arm platform
+    // should consider native build on arm platform
 
-   // used in cross compile 
-   // arm-unknown-linux-musleabihf
-   let target = env::var("TARGET").expect("TARGET was not set");
-   if target.contains("arm") && target.contains("musl") {
-      // find and link static sqlite3 lib
-    let sql=Path::new(&env::current_dir().unwrap()).join("sql/lib");
-    println!("cargo:rustc-link-search=native={}",sql.display());
-    println!("cargo:rustc-link-lib=static=sqlite3");
-   }
+    // used in cross compile
+    // arm-unknown-linux-musleabihf
+    let target = env::var("TARGET").expect("TARGET was not set");
+    if target.contains("arm") && target.contains("musl") {
+        // find and link static sqlite3 lib
+        let sql = Path::new(&env::current_dir().unwrap()).join("sql/lib");
+        println!("cargo:rustc-link-search=native={}", sql.display());
+        println!("cargo:rustc-link-lib=static=sqlite3");
+    }
 
-   let pat = "rustls";
-   let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
-   if env::var_os(key).is_some() {
-       println!("cargo:rustc-cfg=feature=\"{}\"", pat)
-   }
+    let pat = "rustls";
+    let key = format!("CARGO_FEATURE_{}", pat).to_uppercase();
+    if env::var_os(key).is_some() {
+        println!("cargo:rustc-cfg=feature=\"{}\"", pat)
+    }
 }

--- a/scripts/cc.sh
+++ b/scripts/cc.sh
@@ -25,19 +25,34 @@ if [ -f $file2 ];then
  echo "$file2 exists"
 else
 # set CC locenv var
-export PATH="$HOME/rpitools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH"
-export CC=arm-linux-gnueabihf-gcc
+# export PATH="$HOME/rpitools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin:$PATH"
+# export CC=arm-linux-gnueabihf-gcc
 # add env var
-# export PATH="$HOME/arm-linux-musleabihf-cross/bin:$PATH"
+ export PATH="$HOME/arm-linux-musleabihf-cross/bin:$PATH"
 # use compiled openssl
-export OPENSSL_LIB_DIR=/home/ubuntu/openssl-armv7/lib
-export OPENSSL_INCLUDE_DIR=/home/ubuntu/openssl-armv7/include
+export OPENSSL_LIB_DIR=/home/ubuntu/anki-sync-server-rs/openssl/lib
+export OPENSSL_INCLUDE_DIR=/home/ubuntu/anki-sync-server-rs/openssl/include
 export OPENSSL_STATIC=true
+
+mkdir -p $HOME/sql
+#  export PATH="$HOME/arm-linux-musleabihf-cross/bin:$PATH"
+# export CC=arm-linux-musleabihf-gcc
+
+
+cd $HOME/sqlite-autoconf-3380200
+# make clean
+./configure CC=$HOME/rpitools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf/bin/arm-linux-gnueabihf-gcc  --host=arm-linux --prefix=$HOME/sql
+          make && make install
+
+
+cd $HOME/anki-sync-server-rs
+
+cp -r $HOME/sql .
 # cross build for armv7 enable feature --features rustls
- cargo build --target armv7-unknown-linux-musleabihf --release
+ cargo build --target arm-unknown-linux-musleabihf --release --features tls
 
 mkdir ankisyncd-arm
-cp target/armv7-unknown-linux-musleabihf/release/ankisyncd ankisyncd-arm/
+cp target/arm-unknown-linux-musleabihf/release/ankisyncd ankisyncd-arm/
 cp Settings.toml ankisyncd-arm/
 tar -czvf ankisyncd-$version-arm.tar.gz ankisyncd-arm/
 mv ankisyncd-$version-linux-arm.tar.gz ~


### PR DESCRIPTION
unable to build crate `rusqlite` due to rustc update or something I dont understand.

Eventually,I made it buiding ankisyncd for arm(armv6).And the requirement is that sqlite3 lib must be cross compiled.

native building for arm should use dependency `rusqlite` with feature `bundled` [details](https://crates.io/crates/rusqlite) and I try to include as many platform situations as possible (e.g. armv7h in #22).yet cross compiling should use `rusqlite` without that feature and use local sqlite3 lib.

Other platforms were not affected.And native building for arm on host or docker is also unaffected.