### PR TITLE
Bump-to-0.1.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,9 @@ jobs:
           cp -r $HOME/sql .
           cargo build --target arm-unknown-linux-musleabihf --release --features tls
   
+      - name: Strip binaries (ankisyncd)
+        run: $HOME/arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-strip target/arm-unknown-linux-musleabihf/release
+      
       - name: Create output directory
         run: mkdir output
 
@@ -132,8 +135,8 @@ jobs:
           command: build
           args: --release --features tls
 
-      # - name: Strip binaries (nu)
-      #   run: strip target/release/
+      - name: Strip binaries (ankisyncd)
+        run: strip target/release/
 
       - name: Create output directory
         run: mkdir output
@@ -178,8 +181,8 @@ jobs:
           command: build
           args: --release --features tls 
 
-      # - name: Strip binaries (nu)
-      #   run: strip target/release/nu
+      - name: Strip binaries (ankisyncd)
+        run: strip target/release/ankisyncd
 
       - name: Create output directory
         run: mkdir output
@@ -220,10 +223,6 @@ jobs:
         with:
           command: build
           args: --release --features tls
-
-      # - name: Strip binaries (nu.exe)
-      #   run: strip target/release/nu.exe
-
 
       - name: Create output directory
         run: mkdir output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,8 +144,8 @@ jobs:
       - name: Copy files to output
         run: |
           cp target/release/ankisyncd output/
+          cp scripts/Settings.toml output/
          
-
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "ankisyncd"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "actix-multipart",
  "actix-web",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ankisyncd"
-version = "0.1.5"
+version = "0.1.7"
 edition = "2018"
 license = "AGPL-3.0-or-later"
 documentation = "https://docs.rs/ankisyncd/"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See [reverse proxy setup](docs/REVERSE_PROXY.md) for setting up a reverse proxy 
 
 #### Linux
 
-1. Grab binary from github [releases](https://github.com/ankicommunity/anki-sync-server-rs/releases) and unpack it, `ankisyncd_x.x.x-linux_x86_64_xxx.tar.gz` for x86-64 linux, `ankisyncd-x.x.x-armv7_muslc.tar.gz` for armv7 32bit NEON board under linux) or even better build it from source (see `INSTALL.md`)
+1. Grab binary from github [releases](https://github.com/ankicommunity/anki-sync-server-rs/releases) and unpack it, `ankisyncd_x.x.x-linux_x86_64_xxx.tar.gz` for x86-64 linux, `ankisyncd-x.x.x-armv7_muslc.tar.gz` for armv6 32bit NEON board under linux) or even better build it from source (see `INSTALL.md`)
 2. Tweak the configuration `Settings.toml` to your liking
 3. Run server `./ankisyncd`
 4. Add user `./ankisyncd user --add username password` (use `./ankisyncd user --help` for more on user management)

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -128,4 +128,6 @@ Contribution update :
 - Unwrap reduction 2bis and versions bump:move anki out of source tree,fix run time in run time due to anki update by @redmie
 - Version-bump-update-anki-lib/better clone-patch-anki #29,fork from #18. document about #18, by @redmie,@dobefore
 - Cicd-system #26 by @dobefore and @redmie's suggestions
-- bump ankisyncd to 0.1.5 #30 by @dobefore
+- bump ankisyncd to 0.1.5(test release) #30 by @dobefore
+- fix cross compiling fail for arm(successfully build static bin) #32 by @dobefore
+- bump to 0.1.7 (formal release) 

--- a/docs/CHANGELOG
+++ b/docs/CHANGELOG
@@ -130,4 +130,4 @@ Contribution update :
 - Cicd-system #26 by @dobefore and @redmie's suggestions
 - bump ankisyncd to 0.1.5(test release) #30 by @dobefore
 - fix cross compiling fail for arm(successfully build static bin) #32 by @dobefore
-- bump to 0.1.7 (formal release) 
+- bump to 0.1.7 (first formal release) #33 by @dobefore


### PR DESCRIPTION
this is a first-time formal release by github action.
Through testing with #30 and #32,building actually is working.

linux binary should work on or in  debian-based host or docker.

arm binary should work on armv6,arnv7,aarch64.
